### PR TITLE
[DO NOT MERGE YET] Add 7.1 PHP version and make tag configurable

### DIFF
--- a/openshift/templates/cakephp-mysql-persistent.json
+++ b/openshift/templates/cakephp-mysql-persistent.json
@@ -107,7 +107,7 @@
             "from": {
               "kind": "ImageStreamTag",
               "namespace": "${NAMESPACE}",
-              "name": "php:7.0"
+              "name": "php:${PHP_VERSION}"
             },
             "env":  [
               {
@@ -467,6 +467,13 @@
       "description": "The OpenShift Namespace where the ImageStream resides.",
       "required": true,
       "value": "openshift"
+    },
+    {
+      "name": "PHP_VERSION",
+      "displayName": "PHP Version",
+      "description": "Version of PHP image to be used (5.6, 7.0, 7.1 or latest).",
+      "required": true,
+      "value": "7.1"
     },
     {
       "name": "MEMORY_LIMIT",

--- a/openshift/templates/cakephp-mysql.json
+++ b/openshift/templates/cakephp-mysql.json
@@ -107,7 +107,7 @@
             "from": {
               "kind": "ImageStreamTag",
               "namespace": "${NAMESPACE}",
-              "name": "php:7.0"
+              "name": "php:${PHP_VERSION}"
             },
             "env":  [
               {
@@ -448,6 +448,13 @@
       "description": "The OpenShift Namespace where the ImageStream resides.",
       "required": true,
       "value": "openshift"
+    },
+    {
+      "name": "PHP_VERSION",
+      "displayName": "PHP Version",
+      "description": "Version of PHP image to be used (5.6, 7.0, 7.1 or latest).",
+      "required": true,
+      "value": "7.1"
     },
     {
       "name": "MEMORY_LIMIT",

--- a/openshift/templates/cakephp.json
+++ b/openshift/templates/cakephp.json
@@ -104,7 +104,7 @@
             "from": {
               "kind": "ImageStreamTag",
               "namespace": "${NAMESPACE}",
-              "name": "php:7.0"
+              "name": "php:${PHP_VERSION}"
             },
             "env":  [
               {
@@ -267,6 +267,13 @@
       "description": "The OpenShift Namespace where the ImageStream resides.",
       "required": true,
       "value": "openshift"
+    },
+    {
+      "name": "PHP_VERSION",
+      "displayName": "PHP Version",
+      "description": "Version of PHP image to be used (5.6, 7.0, 7.1 or latest).",
+      "required": true,
+      "value": "7.1"
     },
     {
       "name": "MEMORY_LIMIT",


### PR DESCRIPTION
This is a preparation for the image streams update. Once streams include version 7.1 for the PHP image, this PR can be merged. Until then, the content in https://github.com/hhorak/cakephp-ex serves as a testing app for the PHP image.