### PR TITLE
Fix BZ #1572527: Default Driver when no database in environment

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
     "content-hash": "ac911cb6687b65bfe5e5b520621ab0d6",
@@ -54,16 +54,16 @@
         },
         {
             "name": "cakephp/cakephp",
-            "version": "3.6.1",
+            "version": "3.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/cakephp.git",
-                "reference": "7f97eafa1a95df71ba30b85b744a56c708148467"
+                "reference": "9739f275edd4f97c2a50dc028d870ce51e7aa058"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/cakephp/zipball/7f97eafa1a95df71ba30b85b744a56c708148467",
-                "reference": "7f97eafa1a95df71ba30b85b744a56c708148467",
+                "url": "https://api.github.com/repos/cakephp/cakephp/zipball/9739f275edd4f97c2a50dc028d870ce51e7aa058",
+                "reference": "9739f275edd4f97c2a50dc028d870ce51e7aa058",
                 "shasum": ""
             },
             "require": {
@@ -136,7 +136,7 @@
                 "rapid-development",
                 "validation"
             ],
-            "time": "2018-04-20T01:11:49+00:00"
+            "time": "2018-04-28T02:02:20+00:00"
         },
         {
             "name": "cakephp/chronos",

--- a/config/app.php
+++ b/config/app.php
@@ -257,18 +257,18 @@ return [
     'Datasources' => [
         'default' => [
             'className' => 'Cake\Database\Connection',
-            'driver' => 'Cake\Database\Driver\\' . ucfirst(getenv('DATABASE_ENGINE')),
+            'driver' => 'Cake\Database\Driver\\' . ucfirst(env('DATABASE_ENGINE', 'Mysql')),
             'persistent' => false,
-            'host' => getenv(strtoupper(getenv("DATABASE_SERVICE_NAME"))."_SERVICE_HOST"),
+            'host' => env(strtoupper(env("DATABASE_SERVICE_NAME", 'Mysql'))."_SERVICE_HOST", ''),
             /**
              * CakePHP will use the default DB port based on the driver selected
              * MySQL on MAMP uses port 8889, MAMP users will want to uncomment
              * the following line and set the port accordingly
              */
-            'port' => getenv(strtoupper(getenv("DATABASE_SERVICE_NAME"))."_SERVICE_PORT"),
-            'username' => getenv("DATABASE_USER"),
-            'password' => getenv("DATABASE_PASSWORD"),
-            'database' => getenv("DATABASE_NAME"),
+            'port' => env(strtoupper(env("DATABASE_SERVICE_NAME", 'Mysql'))."_SERVICE_PORT", ''),
+            'username' => env("DATABASE_USER", ''),
+            'password' => env("DATABASE_PASSWORD", ''),
+            'database' => env("DATABASE_NAME", ''),
             'encoding' => 'utf8',
             'timezone' => 'UTC',
             'flags' => [],
@@ -302,7 +302,7 @@ return [
          */
         'test' => [
             'className' => 'Cake\Database\Connection',
-            'driver' => 'Cake\Database\Driver\\' . ucfirst(getenv('DATABASE_ENGINE')),
+            'driver' => 'Cake\Database\Driver\\' . ucfirst(env('DATABASE_ENGINE', 'Mysql')),
             'persistent' => false,
             'database' => 'test_database',
             'encoding' => 'utf8',


### PR DESCRIPTION
The old CakePHP had different error behavior when connecting to a datasource. The new version bubbles an exception up when the driver name is invalid. 

This PR:

1) makes sure there is a valid driver name and avoids the new exception. 
2) pick up the 3.6.1 -> 3.6.2 in composer.lock to stay current.