### PR TITLE
Get rid off EOL php version

### DIFF
--- a/openshift/templates/cakephp-mysql-persistent.json
+++ b/openshift/templates/cakephp-mysql-persistent.json
@@ -463,9 +463,9 @@
     {
       "name": "PHP_VERSION",
       "displayName": "PHP Version",
-      "description": "Version of PHP image to be used (7.1 or latest).",
+      "description": "Version of PHP image to be used (7.3 or latest).",
       "required": true,
-      "value": "7.1"
+      "value": "7.3"
     },
     {
       "name": "MEMORY_LIMIT",

--- a/openshift/templates/cakephp-mysql.json
+++ b/openshift/templates/cakephp-mysql.json
@@ -444,9 +444,9 @@
     {
       "name": "PHP_VERSION",
       "displayName": "PHP Version",
-      "description": "Version of PHP image to be used (7.1 or latest).",
+      "description": "Version of PHP image to be used (7.3 or latest).",
       "required": true,
-      "value": "7.1"
+      "value": "7.3"
     },
     {
       "name": "MEMORY_LIMIT",

--- a/openshift/templates/cakephp.json
+++ b/openshift/templates/cakephp.json
@@ -263,9 +263,9 @@
     {
       "name": "PHP_VERSION",
       "displayName": "PHP Version",
-      "description": "Version of PHP image to be used (7.1 or latest).",
+      "description": "Version of PHP image to be used (7.3 or latest).",
       "required": true,
-      "value": "7.1"
+      "value": "7.3"
     },
     {
       "name": "MEMORY_LIMIT",


### PR DESCRIPTION
This pull request removes EOL PHP images.
OpenShift templates now uses PHP 7.3 version by default

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>