### PR TITLE
move openshift templates off of EOL mysql 5.7

### DIFF
--- a/openshift/templates/cakephp-mysql-persistent.json
+++ b/openshift/templates/cakephp-mysql-persistent.json
@@ -352,7 +352,7 @@
               "from": {
                 "kind": "ImageStreamTag",
                 "namespace": "${NAMESPACE}",
-                "name": "mysql:5.7"
+                "name": "mysql:8.0"
               }
             }
           },

--- a/openshift/templates/cakephp-mysql.json
+++ b/openshift/templates/cakephp-mysql.json
@@ -335,7 +335,7 @@
               "from": {
                 "kind": "ImageStreamTag",
                 "namespace": "${NAMESPACE}",
-                "name": "mysql:5.7"
+                "name": "mysql:8.0"
               }
             }
           },


### PR DESCRIPTION
@phracek @pkubatrh @hhorak PTAL

in the interim I'm patching the openshift 4.x samples operator to avoid issues with the recent imagestream EOL removals