### PR TITLE
Add MYSQL_DEFAULT_AUTHENTICATION_PLUGIN as a configurable parameter

### DIFF
--- a/openshift/templates/cakephp-mysql.json
+++ b/openshift/templates/cakephp-mysql.json
@@ -275,6 +275,10 @@
                   {
                     "name": "OPCACHE_REVALIDATE_FREQ",
                     "value": "${OPCACHE_REVALIDATE_FREQ}"
+                  },
+                  {
+                    "name": "MYSQL_DEFAULT_AUTHENTICATION_PLUGIN",
+                    "value": "${MYSQL_DEFAULT_AUTHENTICATION_PLUGIN}"
                   }
                 ],
                 "resources": {
@@ -548,6 +552,12 @@
       "displayName": "Custom Composer Mirror URL",
       "description": "The custom Composer mirror URL",
       "value": ""
+    },
+    {
+      "name": "MYSQL_DEFAULT_AUTHENTICATION_PLUGIN",
+      "displayName": "MySQL authentication plugin",
+      "description": "The custom MySQL default authentication plugin (default: mysql_native_password), might be changed to caching_sha2_password once PHP client supports it.",
+      "value": "mysql_native_password"
     }
   ]
 }


### PR DESCRIPTION
This is related to https://github.com/sclorg/mysql-container/pull/280 and https://bugzilla.redhat.com/show_bug.cgi?id=1793116. The problem is that the `mysqli` doesn't support the new default authentication plugin that MySQL 8.0 introduced, and so we need to use the older one for PHP apps.