### PR TITLE
Add MYSQL_DEFAULT_AUTHENTICATION_PLUGIN as a configurable parameter

### DIFF
--- a/openshift/templates/cakephp-mysql-persistent.json
+++ b/openshift/templates/cakephp-mysql-persistent.json
@@ -431,6 +431,10 @@
                   {
                     "name": "MYSQL_DATABASE",
                     "value": "${DATABASE_NAME}"
+                  },
+                  {
+                    "name": "MYSQL_DEFAULT_AUTHENTICATION_PLUGIN",
+                    "value": "${MYSQL_DEFAULT_AUTHENTICATION_PLUGIN}"
                   }
                 ],
                 "resources": {
@@ -574,6 +578,12 @@
       "displayName": "Custom Composer Mirror URL",
       "description": "The custom Composer mirror URL",
       "value": ""
+    },
+    {
+      "name": "MYSQL_DEFAULT_AUTHENTICATION_PLUGIN",
+      "displayName": "MySQL authentication plugin",
+      "description": "The custom MySQL default authentication plugin (default: mysql_native_password), might be changed to caching_sha2_password once PHP client supports it.",
+      "value": "mysql_native_password"
     }
   ]
 }

--- a/openshift/templates/cakephp-mysql.json
+++ b/openshift/templates/cakephp-mysql.json
@@ -208,7 +208,7 @@
                 "readinessProbe": {
                   "timeoutSeconds": 3,
                   "initialDelaySeconds": 3,
-                  "periodSeconds": 60,                  
+                  "periodSeconds": 60,
                   "httpGet": {
                     "path": "/health.php",
                     "port": 8080
@@ -412,6 +412,10 @@
                   {
                     "name": "MYSQL_DATABASE",
                     "value": "${DATABASE_NAME}"
+                  },
+                  {
+                    "name": "MYSQL_DEFAULT_AUTHENTICATION_PLUGIN",
+                    "value": "${MYSQL_DEFAULT_AUTHENTICATION_PLUGIN}"
                   }
                 ],
                 "resources": {
@@ -548,6 +552,12 @@
       "displayName": "Custom Composer Mirror URL",
       "description": "The custom Composer mirror URL",
       "value": ""
+    },
+    {
+       "name": "MYSQL_DEFAULT_AUTHENTICATION_PLUGIN",
+       "displayName": "MySQL authentication plugin",
+       "description": "The custom MySQL default authentication plugin (default: mysql_native_password), might be changed to caching_sha2_password once PHP client supports it.",
+       "value": "mysql_native_password"
     }
   ]
 }


### PR DESCRIPTION
Replacement for https://github.com/sclorg/cakephp-ex/pull/114

@hhorak based on testing in https://github.com/openshift/cluster-samples-operator/pull/308 @yselkowitz and I determined these templates now work again on openshift 4.x if we set MYSQL_DEFAULT_AUTHENTICATION_PLUGIN on the mysql DeploymentConfig vs. setting on the cakephp DC per what was done in https://github.com/sclorg/cakephp-ex/pull/114

Can we go ahead and merge this PR then vs. https://github.com/sclorg/cakephp-ex/pull/114

thanks

With that, once openshift/library background processing pulls this change in, and I can re-validate via https://github.com/openshift/cluster-samples-operator we can mark https://bugzilla.redhat.com/show_bug.cgi?id=1793116 verified 
