### PR TITLE
Drop mentions of php:7.3-ubi8

### DIFF
--- a/openshift/templates/cakephp-mysql-persistent.json
+++ b/openshift/templates/cakephp-mysql-persistent.json
@@ -467,7 +467,7 @@
     {
       "name": "PHP_VERSION",
       "displayName": "PHP Version",
-      "description": "Version of PHP image to be used (7.3-ubi7, 7.3-ubi8, 7.4-ubi8, or latest).",
+      "description": "Version of PHP image to be used (7.3-ubi7, 7.4-ubi8, or latest).",
       "required": true,
       "value": "7.4-ubi8"
     },

--- a/openshift/templates/cakephp-mysql.json
+++ b/openshift/templates/cakephp-mysql.json
@@ -448,7 +448,7 @@
     {
       "name": "PHP_VERSION",
       "displayName": "PHP Version",
-      "description": "Version of PHP image to be used (7.3-ubi7, 7.3-ubi8, 7.4-ubi8, or latest).",
+      "description": "Version of PHP image to be used (7.3-ubi7, 7.4-ubi8, or latest).",
       "required": true,
       "value": "7.4-ubi8"
     },

--- a/openshift/templates/cakephp.json
+++ b/openshift/templates/cakephp.json
@@ -263,7 +263,7 @@
     {
       "name": "PHP_VERSION",
       "displayName": "PHP Version",
-      "description": "Version of PHP image to be used (7.3-ubi7, 7.3-ubi8, 7.4-ubi8, or latest).",
+      "description": "Version of PHP image to be used (7.3-ubi7, 7.4-ubi8, or latest).",
       "required": true,
       "value": "7.4-ubi8"
     },


### PR DESCRIPTION
That version of PHP is out of support and being dropped from 4.10 imagestreams.
